### PR TITLE
feat: suppor control api

### DIFF
--- a/src/audio.dhd.s52.sdPlugin/app.html
+++ b/src/audio.dhd.s52.sdPlugin/app.html
@@ -1,31 +1,30 @@
-<!DOCTYPE HTML>
+<!doctype html>
 <html>
-
-<head>
+  <head>
     <title>audio.dhd.s52</title>
-    <meta charset="utf-8"/>
+    <meta charset="utf-8" />
     <style>
-        canvas {
-            background-color: transparent;
-        }
+      canvas {
+        background-color: transparent;
+      }
     </style>
-</head>
+  </head>
 
-<body>
-	<!-- Stream Deck Libs -->
+  <body>
+    <!-- Stream Deck Libs -->
     <script src="libs/js/constants.js"></script>
-	<script src="libs/js/prototypes.js"></script>
-	<script src="libs/js/timers.js"></script>
-	<script src="libs/js/utils.js"></script>
+    <script src="libs/js/prototypes.js"></script>
+    <script src="libs/js/timers.js"></script>
+    <script src="libs/js/utils.js"></script>
     <script src="libs/js/events.js"></script>
-	<script src="libs/js/api.js"></script>
+    <script src="libs/js/api.js"></script>
     <script src="libs/js/stream-deck.js"></script>
-	<script src="libs/js/action.js"></script>
+    <script src="libs/js/action.js"></script>
 
-	<!-- Plugin Source -->
+    <!-- Plugin Source -->
 
     <script src="assets.js"></script>
+    <script src="lodash.get.js"></script>
     <script src="app.js"></script>
-</body>
-
+  </body>
 </html>

--- a/src/audio.dhd.s52.sdPlugin/common/btn-PI/inspector.html
+++ b/src/audio.dhd.s52.sdPlugin/common/btn-PI/inspector.html
@@ -1,54 +1,46 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-
-<head>
+  <head>
     <meta charset="utf-8" />
     <meta
-          name="viewport"
-          content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,minimal-ui,viewport-fit=cover" />
+      name="viewport"
+      content="width=device-width,initial-scale=1,maximum-scale=1,minimum-scale=1,user-scalable=no,minimal-ui,viewport-fit=cover"
+    />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <title>audio.dhd.s52 Property Inspector</title>
     <link rel="stylesheet" href="../../libs/css/sdpi.css" />
     <style>
-        .center-button {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
+      .center-button {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
     </style>
-</head>
+  </head>
 
-<body>
+  <body>
     <div class="sdpi-wrapper">
-        
-        <form id="property-inspector">
-            <div class="sdpi-item" id="keyfunctionSelectWrapper">
-                <div class="sdpi-item-label">Channel</div>
-                <select class="sdpi-item-value select" id="keyfunction">
-                    <option value="0">Mic 1</option>
-                    <option value="1">Mic 2</option>
-                    <option value="2">Bluetooth</option>
-                    <option value="3">Aux</option>
-                    <option value="4">Dante 1/2</option>
-                    <option value="5">Dante 3/4</option>
-                    <option value="6">USB Stereo</option>
-                    <option value="7">USB 1/2</option>
-                    <option value="8">USB 3/4</option>
-                    <option value="9">USB 5/6</option>
-                    <option value="10">USB 7/8</option>
-                    <option value="11">USB 9/10</option>
-                    <option value="12">USB 11/12</option>
-                    <option value="13">USB 13/14</option>
-                    <option value="14">USB 15/16</option>
-                </select>
-            </div>
-            
-            <div class="sdpi-item center-button">
-                <button type="button" id="open-external">Configure RM1 Connection</button>
-            </div>
-        </form>
+      <form id="property-inspector">
+        <div class="sdpi-item">
+          <div class="sdpi-item-label">API Path</div>
 
+          <input
+            class="sdpi-item-value"
+            id="path"
+            name="path"
+            type="text"
+            value=""
+            placeholder="/audio/mixers/0/faders/0/on"
+          />
+        </div>
+
+        <div class="sdpi-item center-button">
+          <button type="button" id="open-external">
+            Configure DHD Device Connection
+          </button>
+        </div>
+      </form>
     </div>
 
     <div class="sdpi-info-label hidden" style="top: -1000" value=""></div>
@@ -65,6 +57,5 @@
 
     <!-- Property Inspector Source -->
     <script src="inspector.js"></script>
-</body>
-
+  </body>
 </html>

--- a/src/audio.dhd.s52.sdPlugin/common/btn-PI/inspector.js
+++ b/src/audio.dhd.s52.sdPlugin/common/btn-PI/inspector.js
@@ -12,13 +12,13 @@ $PI.onConnected((jsn) => {
   console.log(jsn.actionInfo.payload.settings);
 
   settings = jsn.actionInfo.payload.settings;
-  if (settings.keyFunction) {
-    document.querySelector("#keyfunction").value = settings.keyFunction;
+  if (settings.path) {
+    document.querySelector("#path").value = settings.path;
   } else {
-    document.querySelector("#keyfunction").value = "0";
+    document.querySelector("#path").value = "/audio/mixers/0/faders/0/on";
 
     const payload = {
-      keyFunction: 1,
+      path: "/audio/mixers/0/faders/0/on",
     };
 
     $PI.setSettings(payload);
@@ -40,12 +40,12 @@ $PI.onConnected((jsn) => {
   $PI.getGlobalSettings();
 });
 
-document.querySelector("#keyfunction").addEventListener("change", (event) => {
-  const selectedValue = event.target.value;
-  console.log("Selected key function:", selectedValue);
+document.querySelector("#path").addEventListener("keyup", (event) => {
+  const { value } = event.target;
+  console.log("Selected path:", value);
 
   const payload = {
-    keyFunction: selectedValue,
+    path: value,
   };
 
   $PI.setSettings(payload);

--- a/src/audio.dhd.s52.sdPlugin/en.json
+++ b/src/audio.dhd.s52.sdPlugin/en.json
@@ -1,9 +1,9 @@
 {
-  "Description": "RM1 Stream Deck Plugin", 
-  "Name": "RM1", 
-  "Category": "Templates", 
+  "Description": "RM1 Stream Deck Plugin",
+  "Name": "RM1",
+  "Category": "Templates",
   "com.elgato.template.action": {
-    "Name": "Action", 
+    "Name": "Action",
     "Tooltip": "This is the only action in this plugin"
   },
   "Localization": {

--- a/src/audio.dhd.s52.sdPlugin/external.html
+++ b/src/audio.dhd.s52.sdPlugin/external.html
@@ -59,8 +59,9 @@
       <div class="sdpi-heading">Configure DHD Connection</div>
       <div class="wrap">
         <p>
-          Here you can configure the connection to your DHD device. Enter the
-          device IP address or hostname and Token and click save.
+          You can configure the connection to your DHD Device here. Simply enter
+          the device's IP address or hostname, along with the API token, and
+          click "Save" to apply the settings.
         </p>
       </div>
 
@@ -84,8 +85,7 @@
             id="dhdToken"
             name="dhd-token"
             type="text"
-            value=""
-            placeholder="XYZ"
+            placeholder="xxxxxxxx-xxxxxxxx-xxxxxxxx-xxxxxxxx"
           />
         </div>
 

--- a/src/audio.dhd.s52.sdPlugin/lodash.get.js
+++ b/src/audio.dhd.s52.sdPlugin/lodash.get.js
@@ -1,0 +1,962 @@
+/**
+ * lodash (Custom Build) <https://lodash.com/>
+ * Build: `lodash modularize exports="npm" -o ./`
+ * Copyright jQuery Foundation and other contributors <https://jquery.org/>
+ * Released under MIT license <https://lodash.com/license>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ */
+
+/** Used as the `TypeError` message for "Functions" methods. */
+var FUNC_ERROR_TEXT = "Expected a function";
+
+/** Used to stand-in for `undefined` hash values. */
+var HASH_UNDEFINED = "__lodash_hash_undefined__";
+
+/** Used as references for various `Number` constants. */
+var INFINITY = 1 / 0;
+
+/** `Object#toString` result references. */
+var funcTag = "[object Function]",
+  genTag = "[object GeneratorFunction]",
+  symbolTag = "[object Symbol]";
+
+/** Used to match property names within property paths. */
+var reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
+  reIsPlainProp = /^\w*$/,
+  reLeadingDot = /^\./,
+  rePropName =
+    /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
+
+/**
+ * Used to match `RegExp`
+ * [syntax characters](http://ecma-international.org/ecma-262/7.0/#sec-patterns).
+ */
+var reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
+
+/** Used to match backslashes in property paths. */
+var reEscapeChar = /\\(\\)?/g;
+
+/** Used to detect host constructors (Safari). */
+var reIsHostCtor = /^\[object .+?Constructor\]$/;
+
+/** Detect free variable `global` from Node.js. */
+var freeGlobal =
+  typeof global == "object" && global && global.Object === Object && global;
+
+/** Detect free variable `self`. */
+var freeSelf =
+  typeof self == "object" && self && self.Object === Object && self;
+
+/** Used as a reference to the global object. */
+var root = freeGlobal || freeSelf || Function("return this")();
+
+/**
+ * Gets the value at `key` of `object`.
+ *
+ * @private
+ * @param {Object} [object] The object to query.
+ * @param {string} key The key of the property to get.
+ * @returns {*} Returns the property value.
+ */
+function getValue(object, key) {
+  return object == null ? undefined : object[key];
+}
+
+/**
+ * Checks if `value` is a host object in IE < 9.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a host object, else `false`.
+ */
+function isHostObject(value) {
+  // Many host objects are `Object` objects that can coerce to strings
+  // despite having improperly defined `toString` methods.
+  var result = false;
+  if (value != null && typeof value.toString != "function") {
+    try {
+      result = !!(value + "");
+    } catch (e) {}
+  }
+  return result;
+}
+
+/** Used for built-in method references. */
+var arrayProto = Array.prototype,
+  funcProto = Function.prototype,
+  objectProto = Object.prototype;
+
+/** Used to detect overreaching core-js shims. */
+var coreJsData = root["__core-js_shared__"];
+
+/** Used to detect methods masquerading as native. */
+var maskSrcKey = (function () {
+  var uid = /[^.]+$/.exec(
+    (coreJsData && coreJsData.keys && coreJsData.keys.IE_PROTO) || "",
+  );
+  return uid ? "Symbol(src)_1." + uid : "";
+})();
+
+/** Used to resolve the decompiled source of functions. */
+var funcToString = funcProto.toString;
+
+/** Used to check objects for own properties. */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/**
+ * Used to resolve the
+ * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
+ * of values.
+ */
+var objectToString = objectProto.toString;
+
+/** Used to detect if a method is native. */
+var reIsNative = RegExp(
+  "^" +
+    funcToString
+      .call(hasOwnProperty)
+      .replace(reRegExpChar, "\\$&")
+      .replace(
+        /hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g,
+        "$1.*?",
+      ) +
+    "$",
+);
+
+/** Built-in value references. */
+var Symbol = root.Symbol,
+  splice = arrayProto.splice;
+
+/* Built-in method references that are verified to be native. */
+var Map = getNative(root, "Map"),
+  nativeCreate = getNative(Object, "create");
+
+/** Used to convert symbols to primitives and strings. */
+var symbolProto = Symbol ? Symbol.prototype : undefined,
+  symbolToString = symbolProto ? symbolProto.toString : undefined;
+
+/**
+ * Creates a hash object.
+ *
+ * @private
+ * @constructor
+ * @param {Array} [entries] The key-value pairs to cache.
+ */
+function Hash(entries) {
+  var index = -1,
+    length = entries ? entries.length : 0;
+
+  this.clear();
+  while (++index < length) {
+    var entry = entries[index];
+    this.set(entry[0], entry[1]);
+  }
+}
+
+/**
+ * Removes all key-value entries from the hash.
+ *
+ * @private
+ * @name clear
+ * @memberOf Hash
+ */
+function hashClear() {
+  this.__data__ = nativeCreate ? nativeCreate(null) : {};
+}
+
+/**
+ * Removes `key` and its value from the hash.
+ *
+ * @private
+ * @name delete
+ * @memberOf Hash
+ * @param {Object} hash The hash to modify.
+ * @param {string} key The key of the value to remove.
+ * @returns {boolean} Returns `true` if the entry was removed, else `false`.
+ */
+function hashDelete(key) {
+  return this.has(key) && delete this.__data__[key];
+}
+
+/**
+ * Gets the hash value for `key`.
+ *
+ * @private
+ * @name get
+ * @memberOf Hash
+ * @param {string} key The key of the value to get.
+ * @returns {*} Returns the entry value.
+ */
+function hashGet(key) {
+  var data = this.__data__;
+  if (nativeCreate) {
+    var result = data[key];
+    return result === HASH_UNDEFINED ? undefined : result;
+  }
+  return hasOwnProperty.call(data, key) ? data[key] : undefined;
+}
+
+/**
+ * Checks if a hash value for `key` exists.
+ *
+ * @private
+ * @name has
+ * @memberOf Hash
+ * @param {string} key The key of the entry to check.
+ * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
+ */
+function hashHas(key) {
+  var data = this.__data__;
+  return nativeCreate
+    ? data[key] !== undefined
+    : hasOwnProperty.call(data, key);
+}
+
+/**
+ * Sets the hash `key` to `value`.
+ *
+ * @private
+ * @name set
+ * @memberOf Hash
+ * @param {string} key The key of the value to set.
+ * @param {*} value The value to set.
+ * @returns {Object} Returns the hash instance.
+ */
+function hashSet(key, value) {
+  var data = this.__data__;
+  data[key] = nativeCreate && value === undefined ? HASH_UNDEFINED : value;
+  return this;
+}
+
+// Add methods to `Hash`.
+Hash.prototype.clear = hashClear;
+Hash.prototype["delete"] = hashDelete;
+Hash.prototype.get = hashGet;
+Hash.prototype.has = hashHas;
+Hash.prototype.set = hashSet;
+
+/**
+ * Creates an list cache object.
+ *
+ * @private
+ * @constructor
+ * @param {Array} [entries] The key-value pairs to cache.
+ */
+function ListCache(entries) {
+  var index = -1,
+    length = entries ? entries.length : 0;
+
+  this.clear();
+  while (++index < length) {
+    var entry = entries[index];
+    this.set(entry[0], entry[1]);
+  }
+}
+
+/**
+ * Removes all key-value entries from the list cache.
+ *
+ * @private
+ * @name clear
+ * @memberOf ListCache
+ */
+function listCacheClear() {
+  this.__data__ = [];
+}
+
+/**
+ * Removes `key` and its value from the list cache.
+ *
+ * @private
+ * @name delete
+ * @memberOf ListCache
+ * @param {string} key The key of the value to remove.
+ * @returns {boolean} Returns `true` if the entry was removed, else `false`.
+ */
+function listCacheDelete(key) {
+  var data = this.__data__,
+    index = assocIndexOf(data, key);
+
+  if (index < 0) {
+    return false;
+  }
+  var lastIndex = data.length - 1;
+  if (index == lastIndex) {
+    data.pop();
+  } else {
+    splice.call(data, index, 1);
+  }
+  return true;
+}
+
+/**
+ * Gets the list cache value for `key`.
+ *
+ * @private
+ * @name get
+ * @memberOf ListCache
+ * @param {string} key The key of the value to get.
+ * @returns {*} Returns the entry value.
+ */
+function listCacheGet(key) {
+  var data = this.__data__,
+    index = assocIndexOf(data, key);
+
+  return index < 0 ? undefined : data[index][1];
+}
+
+/**
+ * Checks if a list cache value for `key` exists.
+ *
+ * @private
+ * @name has
+ * @memberOf ListCache
+ * @param {string} key The key of the entry to check.
+ * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
+ */
+function listCacheHas(key) {
+  return assocIndexOf(this.__data__, key) > -1;
+}
+
+/**
+ * Sets the list cache `key` to `value`.
+ *
+ * @private
+ * @name set
+ * @memberOf ListCache
+ * @param {string} key The key of the value to set.
+ * @param {*} value The value to set.
+ * @returns {Object} Returns the list cache instance.
+ */
+function listCacheSet(key, value) {
+  var data = this.__data__,
+    index = assocIndexOf(data, key);
+
+  if (index < 0) {
+    data.push([key, value]);
+  } else {
+    data[index][1] = value;
+  }
+  return this;
+}
+
+// Add methods to `ListCache`.
+ListCache.prototype.clear = listCacheClear;
+ListCache.prototype["delete"] = listCacheDelete;
+ListCache.prototype.get = listCacheGet;
+ListCache.prototype.has = listCacheHas;
+ListCache.prototype.set = listCacheSet;
+
+/**
+ * Creates a map cache object to store key-value pairs.
+ *
+ * @private
+ * @constructor
+ * @param {Array} [entries] The key-value pairs to cache.
+ */
+function MapCache(entries) {
+  var index = -1,
+    length = entries ? entries.length : 0;
+
+  this.clear();
+  while (++index < length) {
+    var entry = entries[index];
+    this.set(entry[0], entry[1]);
+  }
+}
+
+/**
+ * Removes all key-value entries from the map.
+ *
+ * @private
+ * @name clear
+ * @memberOf MapCache
+ */
+function mapCacheClear() {
+  this.__data__ = {
+    hash: new Hash(),
+    map: new (Map || ListCache)(),
+    string: new Hash(),
+  };
+}
+
+/**
+ * Removes `key` and its value from the map.
+ *
+ * @private
+ * @name delete
+ * @memberOf MapCache
+ * @param {string} key The key of the value to remove.
+ * @returns {boolean} Returns `true` if the entry was removed, else `false`.
+ */
+function mapCacheDelete(key) {
+  return getMapData(this, key)["delete"](key);
+}
+
+/**
+ * Gets the map value for `key`.
+ *
+ * @private
+ * @name get
+ * @memberOf MapCache
+ * @param {string} key The key of the value to get.
+ * @returns {*} Returns the entry value.
+ */
+function mapCacheGet(key) {
+  return getMapData(this, key).get(key);
+}
+
+/**
+ * Checks if a map value for `key` exists.
+ *
+ * @private
+ * @name has
+ * @memberOf MapCache
+ * @param {string} key The key of the entry to check.
+ * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
+ */
+function mapCacheHas(key) {
+  return getMapData(this, key).has(key);
+}
+
+/**
+ * Sets the map `key` to `value`.
+ *
+ * @private
+ * @name set
+ * @memberOf MapCache
+ * @param {string} key The key of the value to set.
+ * @param {*} value The value to set.
+ * @returns {Object} Returns the map cache instance.
+ */
+function mapCacheSet(key, value) {
+  getMapData(this, key).set(key, value);
+  return this;
+}
+
+// Add methods to `MapCache`.
+MapCache.prototype.clear = mapCacheClear;
+MapCache.prototype["delete"] = mapCacheDelete;
+MapCache.prototype.get = mapCacheGet;
+MapCache.prototype.has = mapCacheHas;
+MapCache.prototype.set = mapCacheSet;
+
+/**
+ * Gets the index at which the `key` is found in `array` of key-value pairs.
+ *
+ * @private
+ * @param {Array} array The array to inspect.
+ * @param {*} key The key to search for.
+ * @returns {number} Returns the index of the matched value, else `-1`.
+ */
+function assocIndexOf(array, key) {
+  var length = array.length;
+  while (length--) {
+    if (eq(array[length][0], key)) {
+      return length;
+    }
+  }
+  return -1;
+}
+
+/**
+ * The base implementation of `_.get` without support for default values.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @param {Array|string} path The path of the property to get.
+ * @returns {*} Returns the resolved value.
+ */
+function baseGet(object, path) {
+  path = isKey(path, object) ? [path] : castPath(path);
+
+  var index = 0,
+    length = path.length;
+
+  while (object != null && index < length) {
+    object = object[toKey(path[index++])];
+  }
+  return index && index == length ? object : undefined;
+}
+
+/**
+ * The base implementation of `_.isNative` without bad shim checks.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a native function,
+ *  else `false`.
+ */
+function baseIsNative(value) {
+  if (!isObject(value) || isMasked(value)) {
+    return false;
+  }
+  var pattern =
+    isFunction(value) || isHostObject(value) ? reIsNative : reIsHostCtor;
+  return pattern.test(toSource(value));
+}
+
+/**
+ * The base implementation of `_.toString` which doesn't convert nullish
+ * values to empty strings.
+ *
+ * @private
+ * @param {*} value The value to process.
+ * @returns {string} Returns the string.
+ */
+function baseToString(value) {
+  // Exit early for strings to avoid a performance hit in some environments.
+  if (typeof value == "string") {
+    return value;
+  }
+  if (isSymbol(value)) {
+    return symbolToString ? symbolToString.call(value) : "";
+  }
+  var result = value + "";
+  return result == "0" && 1 / value == -INFINITY ? "-0" : result;
+}
+
+/**
+ * Casts `value` to a path array if it's not one.
+ *
+ * @private
+ * @param {*} value The value to inspect.
+ * @returns {Array} Returns the cast property path array.
+ */
+function castPath(value) {
+  return isArray(value) ? value : stringToPath(value);
+}
+
+/**
+ * Gets the data for `map`.
+ *
+ * @private
+ * @param {Object} map The map to query.
+ * @param {string} key The reference key.
+ * @returns {*} Returns the map data.
+ */
+function getMapData(map, key) {
+  var data = map.__data__;
+  return isKeyable(key)
+    ? data[typeof key == "string" ? "string" : "hash"]
+    : data.map;
+}
+
+/**
+ * Gets the native function at `key` of `object`.
+ *
+ * @private
+ * @param {Object} object The object to query.
+ * @param {string} key The key of the method to get.
+ * @returns {*} Returns the function if it's native, else `undefined`.
+ */
+function getNative(object, key) {
+  var value = getValue(object, key);
+  return baseIsNative(value) ? value : undefined;
+}
+
+/**
+ * Checks if `value` is a property name and not a property path.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @param {Object} [object] The object to query keys on.
+ * @returns {boolean} Returns `true` if `value` is a property name, else `false`.
+ */
+function isKey(value, object) {
+  if (isArray(value)) {
+    return false;
+  }
+  var type = typeof value;
+  if (
+    type == "number" ||
+    type == "symbol" ||
+    type == "boolean" ||
+    value == null ||
+    isSymbol(value)
+  ) {
+    return true;
+  }
+  return (
+    reIsPlainProp.test(value) ||
+    !reIsDeepProp.test(value) ||
+    (object != null && value in Object(object))
+  );
+}
+
+/**
+ * Checks if `value` is suitable for use as unique object key.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is suitable, else `false`.
+ */
+function isKeyable(value) {
+  var type = typeof value;
+  return type == "string" ||
+    type == "number" ||
+    type == "symbol" ||
+    type == "boolean"
+    ? value !== "__proto__"
+    : value === null;
+}
+
+/**
+ * Checks if `func` has its source masked.
+ *
+ * @private
+ * @param {Function} func The function to check.
+ * @returns {boolean} Returns `true` if `func` is masked, else `false`.
+ */
+function isMasked(func) {
+  return !!maskSrcKey && maskSrcKey in func;
+}
+
+/**
+ * Converts `string` to a property path array.
+ *
+ * @private
+ * @param {string} string The string to convert.
+ * @returns {Array} Returns the property path array.
+ */
+var stringToPath = memoize(function (string) {
+  string = toString(string);
+
+  var result = [];
+  if (reLeadingDot.test(string)) {
+    result.push("");
+  }
+  string.replace(rePropName, function (match, number, quote, string) {
+    result.push(quote ? string.replace(reEscapeChar, "$1") : number || match);
+  });
+  return result;
+});
+
+/**
+ * Converts `value` to a string key if it's not a string or symbol.
+ *
+ * @private
+ * @param {*} value The value to inspect.
+ * @returns {string|symbol} Returns the key.
+ */
+function toKey(value) {
+  if (typeof value == "string" || isSymbol(value)) {
+    return value;
+  }
+  var result = value + "";
+  return result == "0" && 1 / value == -INFINITY ? "-0" : result;
+}
+
+/**
+ * Converts `func` to its source code.
+ *
+ * @private
+ * @param {Function} func The function to process.
+ * @returns {string} Returns the source code.
+ */
+function toSource(func) {
+  if (func != null) {
+    try {
+      return funcToString.call(func);
+    } catch (e) {}
+    try {
+      return func + "";
+    } catch (e) {}
+  }
+  return "";
+}
+
+/**
+ * Creates a function that memoizes the result of `func`. If `resolver` is
+ * provided, it determines the cache key for storing the result based on the
+ * arguments provided to the memoized function. By default, the first argument
+ * provided to the memoized function is used as the map cache key. The `func`
+ * is invoked with the `this` binding of the memoized function.
+ *
+ * **Note:** The cache is exposed as the `cache` property on the memoized
+ * function. Its creation may be customized by replacing the `_.memoize.Cache`
+ * constructor with one whose instances implement the
+ * [`Map`](http://ecma-international.org/ecma-262/7.0/#sec-properties-of-the-map-prototype-object)
+ * method interface of `delete`, `get`, `has`, and `set`.
+ *
+ * @static
+ * @memberOf _
+ * @since 0.1.0
+ * @category Function
+ * @param {Function} func The function to have its output memoized.
+ * @param {Function} [resolver] The function to resolve the cache key.
+ * @returns {Function} Returns the new memoized function.
+ * @example
+ *
+ * var object = { 'a': 1, 'b': 2 };
+ * var other = { 'c': 3, 'd': 4 };
+ *
+ * var values = _.memoize(_.values);
+ * values(object);
+ * // => [1, 2]
+ *
+ * values(other);
+ * // => [3, 4]
+ *
+ * object.a = 2;
+ * values(object);
+ * // => [1, 2]
+ *
+ * // Modify the result cache.
+ * values.cache.set(object, ['a', 'b']);
+ * values(object);
+ * // => ['a', 'b']
+ *
+ * // Replace `_.memoize.Cache`.
+ * _.memoize.Cache = WeakMap;
+ */
+function memoize(func, resolver) {
+  if (
+    typeof func != "function" ||
+    (resolver && typeof resolver != "function")
+  ) {
+    throw new TypeError(FUNC_ERROR_TEXT);
+  }
+  var memoized = function () {
+    var args = arguments,
+      key = resolver ? resolver.apply(this, args) : args[0],
+      cache = memoized.cache;
+
+    if (cache.has(key)) {
+      return cache.get(key);
+    }
+    var result = func.apply(this, args);
+    memoized.cache = cache.set(key, result);
+    return result;
+  };
+  memoized.cache = new (memoize.Cache || MapCache)();
+  return memoized;
+}
+
+// Assign cache to `_.memoize`.
+memoize.Cache = MapCache;
+
+/**
+ * Performs a
+ * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
+ * comparison between two values to determine if they are equivalent.
+ *
+ * @static
+ * @memberOf _
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to compare.
+ * @param {*} other The other value to compare.
+ * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
+ * @example
+ *
+ * var object = { 'a': 1 };
+ * var other = { 'a': 1 };
+ *
+ * _.eq(object, object);
+ * // => true
+ *
+ * _.eq(object, other);
+ * // => false
+ *
+ * _.eq('a', 'a');
+ * // => true
+ *
+ * _.eq('a', Object('a'));
+ * // => false
+ *
+ * _.eq(NaN, NaN);
+ * // => true
+ */
+function eq(value, other) {
+  return value === other || (value !== value && other !== other);
+}
+
+/**
+ * Checks if `value` is classified as an `Array` object.
+ *
+ * @static
+ * @memberOf _
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is an array, else `false`.
+ * @example
+ *
+ * _.isArray([1, 2, 3]);
+ * // => true
+ *
+ * _.isArray(document.body.children);
+ * // => false
+ *
+ * _.isArray('abc');
+ * // => false
+ *
+ * _.isArray(_.noop);
+ * // => false
+ */
+var isArray = Array.isArray;
+
+/**
+ * Checks if `value` is classified as a `Function` object.
+ *
+ * @static
+ * @memberOf _
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a function, else `false`.
+ * @example
+ *
+ * _.isFunction(_);
+ * // => true
+ *
+ * _.isFunction(/abc/);
+ * // => false
+ */
+function isFunction(value) {
+  // The use of `Object#toString` avoids issues with the `typeof` operator
+  // in Safari 8-9 which returns 'object' for typed array and other constructors.
+  var tag = isObject(value) ? objectToString.call(value) : "";
+  return tag == funcTag || tag == genTag;
+}
+
+/**
+ * Checks if `value` is the
+ * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
+ * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
+ *
+ * @static
+ * @memberOf _
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is an object, else `false`.
+ * @example
+ *
+ * _.isObject({});
+ * // => true
+ *
+ * _.isObject([1, 2, 3]);
+ * // => true
+ *
+ * _.isObject(_.noop);
+ * // => true
+ *
+ * _.isObject(null);
+ * // => false
+ */
+function isObject(value) {
+  var type = typeof value;
+  return !!value && (type == "object" || type == "function");
+}
+
+/**
+ * Checks if `value` is object-like. A value is object-like if it's not `null`
+ * and has a `typeof` result of "object".
+ *
+ * @static
+ * @memberOf _
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
+ * @example
+ *
+ * _.isObjectLike({});
+ * // => true
+ *
+ * _.isObjectLike([1, 2, 3]);
+ * // => true
+ *
+ * _.isObjectLike(_.noop);
+ * // => false
+ *
+ * _.isObjectLike(null);
+ * // => false
+ */
+function isObjectLike(value) {
+  return !!value && typeof value == "object";
+}
+
+/**
+ * Checks if `value` is classified as a `Symbol` primitive or object.
+ *
+ * @static
+ * @memberOf _
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
+ * @example
+ *
+ * _.isSymbol(Symbol.iterator);
+ * // => true
+ *
+ * _.isSymbol('abc');
+ * // => false
+ */
+function isSymbol(value) {
+  return (
+    typeof value == "symbol" ||
+    (isObjectLike(value) && objectToString.call(value) == symbolTag)
+  );
+}
+
+/**
+ * Converts `value` to a string. An empty string is returned for `null`
+ * and `undefined` values. The sign of `-0` is preserved.
+ *
+ * @static
+ * @memberOf _
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to process.
+ * @returns {string} Returns the string.
+ * @example
+ *
+ * _.toString(null);
+ * // => ''
+ *
+ * _.toString(-0);
+ * // => '-0'
+ *
+ * _.toString([1, 2, 3]);
+ * // => '1,2,3'
+ */
+function toString(value) {
+  return value == null ? "" : baseToString(value);
+}
+
+/**
+ * Gets the value at `path` of `object`. If the resolved value is
+ * `undefined`, the `defaultValue` is returned in its place.
+ *
+ * @static
+ * @memberOf _
+ * @since 3.7.0
+ * @category Object
+ * @param {Object} object The object to query.
+ * @param {Array|string} path The path of the property to get.
+ * @param {*} [defaultValue] The value returned for `undefined` resolved values.
+ * @returns {*} Returns the resolved value.
+ * @example
+ *
+ * var object = { 'a': [{ 'b': { 'c': 3 } }] };
+ *
+ * _.get(object, 'a[0].b.c');
+ * // => 3
+ *
+ * _.get(object, ['a', '0', 'b', 'c']);
+ * // => 3
+ *
+ * _.get(object, 'a.b.c', 'default');
+ * // => 'default'
+ */
+function get(object, path, defaultValue) {
+  var result = object == null ? undefined : baseGet(object, path);
+  return result === undefined ? defaultValue : result;
+}
+
+module.exports = get;

--- a/src/audio.dhd.s52.sdPlugin/manifest.json
+++ b/src/audio.dhd.s52.sdPlugin/manifest.json
@@ -25,7 +25,7 @@
   "Actions": [
     {
       "Icon": "actions/btnonoff/assets/On-inactive",
-      "Name": "Channel On / Off",
+      "Name": "DHD Control API",
       "Controllers": ["Keypad"],
       "DisableAutomaticStates": true,
       "States": [
@@ -41,46 +41,6 @@
       "Tooltip": "Switch Inputs On or Off",
       "UUID": "audio.dhd.s52.btnonoff",
       "PropertyInspectorPath": "common/btn-PI/inspector.html"
-    },
-    {
-      "Icon": "actions/pflonoff/assets/pfl-inactive",
-      "Name": "PFL On / Off",
-      "Controllers": ["Keypad"],
-      "DisableAutomaticStates": true,
-      "States": [
-        {
-          "Image": "actions/pflonoff/assets/pfl-active",
-          "Name": "on"
-        },
-        {
-          "Image": "actions/pflonoff/assets/pfl-inactive",
-          "Name": "off"
-        }
-      ],
-      "Tooltip": "Switch PFL On or Off",
-      "UUID": "audio.dhd.s52.pflonoff",
-      "PropertyInspectorPath": "common/btn-PI/inspector.html"
-    },
-    {
-      "Icon": "actions/encoder/assets/hpvol",
-      "Name": "HP 1",
-      "Controllers": ["Encoder"],
-      "DisableAutomaticStates": true,
-      "States": [
-        {
-          "Image": "actions/encoder/assets/hpvol",
-          "Name": "Encoder"
-        }
-      ],
-      "Encoder": {
-        "Icon": "actions/encoder/assets/hpvol",
-        "layout": "$B1",
-        "TriggerDescription": {
-          "Rotate": "Change the volume"
-        }
-      },
-      "Tooltip": "Set headphone 1 encoder",
-      "UUID": "audio.dhd.s52.hp1vol"
     }
   ]
 }


### PR DESCRIPTION
Unter "Configure DHD Device Connection" kann jetzt IP und `token` hinterlegt werden. 
Die Actions haben jetzt **nur** noch ein "API Path" `input` field. 

Ich habe folgende Pfade getestet:

* `/audio/mixers/0/faders/4/on`
* `audio/mixers/0/faders/0/pfl1`
* `/control/logics/35/value`

:exclamation: Ich konnte die Potis nicht testen. Deshalb habe ich diesen Teil entfernt.